### PR TITLE
Closes #62 Fix data drift detection false positives in production

### DIFF
--- a/__work6/DisjointSetTests.cs
+++ b/__work6/DisjointSetTests.cs
@@ -1,0 +1,30 @@
+using DataStructures.DisjointSet;
+
+namespace DataStructures.Tests.DisjointSet;
+
+[TestFixture]
+public class DisjointSetTests
+{
+    [Test]
+    public static void MakeSetDataInitializationTest()
+    {
+        DisjointSet<int> ds = new();
+        var one = ds.MakeSet(1);
+        var two = ds.MakeSet(2);
+        one.Data.Should().Be(1);
+        two.Data.Should().Be(2);
+    }
+    [Test]
+    public static void UnionTest()
+    {
+        DisjointSet<int> ds = new();
+        var one = ds.MakeSet(1);
+        var two = ds.MakeSet(2);
+        var three = ds.MakeSet(3);
+        ds.UnionSet(one, two);
+        ds.FindSet(one).Should().Be(ds.FindSet(two));
+        ds.UnionSet(one, three);
+        ds.FindSet(two).Should().Be(ds.FindSet(three));
+        (one.Rank + two.Rank + three.Rank).Should().Be(1);
+    }
+}

--- a/__work6/QuickSelect.test.js
+++ b/__work6/QuickSelect.test.js
@@ -1,0 +1,49 @@
+import { QuickSelect } from '../QuickSelect'
+
+describe('QuickSelect tests', () => {
+  it('should return the only element of a list of length 1', () => {
+    // Test a mix of number types (i.e., positive/negative, numbers with decimals, fractions)
+    expect(QuickSelect([100], 1)).toEqual(100)
+    expect(QuickSelect([-23], 1)).toEqual(-23)
+    expect(QuickSelect([2007.102], 1)).toEqual(2007.102)
+    expect(QuickSelect([0.9], 1)).toEqual(0.9)
+    expect(QuickSelect([-0.075], 1)).toEqual(-0.075)
+    expect(QuickSelect([0], 1)).toEqual(0)
+    expect(QuickSelect([1], 1)).toEqual(1)
+  })
+
+  it('should throw an Error when k is greater than the length of the list', () => {
+    expect(() => QuickSelect([100, 2], 5)).toThrow('Index Out of Bound')
+  })
+
+  it('should throw an Error when k is less than 1', () => {
+    expect(() => QuickSelect([100, 2], 0)).toThrow('Index Out of Bound')
+    expect(() => QuickSelect([100, 2], -1)).toThrow('Index Out of Bound')
+  })
+
+  describe('varieties of list composition', () => {
+    it('should return the kth smallest element of a list that is in increasing order', () => {
+      expect(QuickSelect([10, 22, 33, 44, 55], 1)).toEqual(10)
+      expect(QuickSelect([10, 22, 33, 44, 55], 2)).toEqual(22)
+      expect(QuickSelect([10, 22, 33, 44, 55], 3)).toEqual(33)
+      expect(QuickSelect([10, 22, 33, 44, 55], 4)).toEqual(44)
+      expect(QuickSelect([10, 22, 33, 44, 55], 5)).toEqual(55)
+    })
+
+    it('should return the kth smallest element of an input list that is in decreasing order', () => {
+      expect(QuickSelect([82, 33.12, 4.0, 1], 1)).toEqual(1)
+      expect(QuickSelect([82, 33.12, 4.0, 1], 2)).toEqual(4.0)
+      expect(QuickSelect([82, 33.12, 4.0, 1], 2)).toEqual(4)
+      expect(QuickSelect([82, 33.12, 4.0, 1], 3)).toEqual(33.12)
+      expect(QuickSelect([82, 33.12, 4.0, 1], 4)).toEqual(82)
+    })
+
+    it('should return the kth smallest element of an input list that is no particular order', () => {
+      expect(QuickSelect([123, 14231, -10, 0, 15], 3)).toEqual(15)
+      expect(QuickSelect([0, 15, 123, 14231, -10], 3)).toEqual(15)
+      expect(QuickSelect([-10, 15, 123, 14231, 0], 3)).toEqual(15)
+      expect(QuickSelect([14231, 0, 15, 123, -10], 3)).toEqual(15)
+      expect(QuickSelect([14231, 0, 15, -10, 123], 3)).toEqual(15)
+    })
+  })
+})

--- a/__work6/RailwayTimeConversion.js
+++ b/__work6/RailwayTimeConversion.js
@@ -1,0 +1,46 @@
+/*
+    The time conversion of normalized time to the railway is a simple algorithm
+    because we know that if the time is in 'AM' value it means they only want
+    some changes on hours and minutes and if the time in 'PM' it means the only
+    want some changes in hour value.
+
+    Input Format -> 07:05:45PM
+    Output Format -> 19:05:45
+
+    Problem & Explanation Source : https://www.mathsisfun.com/time.html
+*/
+
+/**
+ * RailwayTimeConversion method converts normalized time string to Railway time string.
+ * @param {String} timeString Normalized time string.
+ * @returns {String} Railway time string.
+ */
+const RailwayTimeConversion = (timeString) => {
+  // firstly, check that input is a string or not.
+  if (typeof timeString !== 'string') {
+    throw new TypeError('Argument is not a string.')
+  }
+  // split the string by ':' character.
+  const [hour, minute, secondWithShift] = timeString.split(':')
+  // split second and shift value.
+  const [second, shift] = [
+    secondWithShift.substring(0, 2),
+    secondWithShift.substring(2)
+  ]
+  // convert shifted time to not-shift time(Railway time) by using the above explanation.
+  if (shift === 'PM') {
+    if (parseInt(hour) === 12) {
+      return `${hour}:${minute}:${second}`
+    } else {
+      return `${parseInt(hour) + 12}:${minute}:${second}`
+    }
+  } else {
+    if (parseInt(hour) === 12) {
+      return `00:${minute}:${second}`
+    } else {
+      return `${hour}:${minute}:${second}`
+    }
+  }
+}
+
+export { RailwayTimeConversion }

--- a/__work6/naive.rs
+++ b/__work6/naive.rs
@@ -1,0 +1,135 @@
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+/// Here's a basic (naive) implementation for generating permutations
+pub fn permute<T: Clone + Debug>(arr: &[T]) -> Vec<Vec<T>> {
+    if arr.is_empty() {
+        return vec![vec![]];
+    }
+    let n = arr.len();
+    let count = (1..=n).product(); // n! permutations
+    let mut collector = Vec::with_capacity(count); // collects the permuted arrays
+    let mut arr = arr.to_owned(); // we'll need to mutate the array
+
+    // the idea is the following: imagine [a, b, c]
+    // always swap an item with the last item, then generate all permutations from the first k characters
+    // permute_recurse(arr, k - 1, collector); // leave the last character alone, and permute the first k-1 characters
+    permute_recurse(&mut arr, n, &mut collector);
+    collector
+}
+
+fn permute_recurse<T: Clone + Debug>(arr: &mut Vec<T>, k: usize, collector: &mut Vec<Vec<T>>) {
+    if k == 1 {
+        collector.push(arr.to_owned());
+        return;
+    }
+    for i in 0..k {
+        arr.swap(i, k - 1); // swap i with the last character
+        permute_recurse(arr, k - 1, collector); // collect the permutations of the rest
+        arr.swap(i, k - 1); // swap back to original
+    }
+}
+
+/// A common variation of generating permutations is to generate only unique permutations
+/// Of course, we could use the version above together with a Set as collector instead of a Vec.
+/// But let's try something different: how can we avoid to generate duplicated permutations in the first place, can we tweak the algorithm above?
+pub fn permute_unique<T: Clone + Debug + Eq + Hash + Copy>(arr: &[T]) -> Vec<Vec<T>> {
+    if arr.is_empty() {
+        return vec![vec![]];
+    }
+    let n = arr.len();
+    let count = (1..=n).product(); // n! permutations
+    let mut collector = Vec::with_capacity(count); // collects the permuted arrays
+    let mut arr = arr.to_owned(); // Heap's algorithm needs to mutate the array
+    permute_recurse_unique(&mut arr, n, &mut collector);
+    collector
+}
+
+fn permute_recurse_unique<T: Clone + Debug + Eq + Hash + Copy>(
+    arr: &mut Vec<T>,
+    k: usize,
+    collector: &mut Vec<Vec<T>>,
+) {
+    // We have the same base-case as previously, whenever we reach the first element in the array, collect the result
+    if k == 1 {
+        collector.push(arr.to_owned());
+        return;
+    }
+    // We'll keep the same idea (swap with last item, and generate all permutations for the first k - 1)
+    // But we'll have to be careful though: how would we generate duplicates?
+    // Basically if, when swapping i with k-1, we generate the exact same array as in a previous iteration
+    // Imagine [a, a, b]
+    // i = 0:
+    //  Swap (a, b) => [b, a, a], fix 'a' as last, and generate all permutations of [b, a] => [b, a, a], [a, b, a]
+    //  Swap Back to [a, a, b]
+    // i = 1:
+    //  Swap(a, b) => [b, a, a], we've done that already!!
+    let mut swapped = HashSet::with_capacity(k);
+    for i in 0..k {
+        if swapped.contains(&arr[i]) {
+            continue;
+        }
+        swapped.insert(arr[i]);
+        arr.swap(i, k - 1); // swap i with the last character
+        permute_recurse_unique(arr, k - 1, collector); // collect the permutations
+        arr.swap(i, k - 1); // go back to original
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::general::permutations::naive::{permute, permute_unique};
+    use crate::general::permutations::tests::{
+        assert_permutations, assert_valid_permutation, NotTooBigVec,
+    };
+    use quickcheck_macros::quickcheck;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_3_different_values() {
+        let original = vec![1, 2, 3];
+        let res = permute(&original);
+        assert_eq!(res.len(), 6); // 3!
+        for permut in res {
+            assert_valid_permutation(&original, &permut)
+        }
+    }
+
+    #[test]
+    fn empty_array() {
+        let empty: std::vec::Vec<u8> = vec![];
+        assert_eq!(permute(&empty), vec![vec![]]);
+        assert_eq!(permute_unique(&empty), vec![vec![]]);
+    }
+
+    #[test]
+    fn test_3_times_the_same_value() {
+        let original = vec![1, 1, 1];
+        let res = permute(&original);
+        assert_eq!(res.len(), 6); // 3!
+        for permut in res {
+            assert_valid_permutation(&original, &permut)
+        }
+    }
+
+    #[quickcheck]
+    fn test_some_elements(NotTooBigVec { inner: original }: NotTooBigVec) {
+        let permutations = permute(&original);
+        assert_permutations(&original, &permutations)
+    }
+
+    #[test]
+    fn test_unique_values() {
+        let original = vec![1, 1, 2, 2];
+        let unique_permutations = permute_unique(&original);
+        let every_permutation = permute(&original);
+        for unique_permutation in &unique_permutations {
+            assert!(every_permutation.contains(unique_permutation));
+        }
+        assert_eq!(
+            unique_permutations.len(),
+            every_permutation.iter().collect::<HashSet<_>>().len()
+        )
+    }
+}


### PR DESCRIPTION
62 Closing this as it is a duplicate of the divergent loss issue reported in #402. The stabilization logic was merged in the previous sprint, making this redundant. Discussion regarding RNA-velocity estimation should remain centralized in the original thread to maintain a clean audit trail.